### PR TITLE
Improve Pod Initialization

### DIFF
--- a/Arm-Architecture/Dockerfiles/open5gs-epc/open5gs-epc-aio
+++ b/Arm-Architecture/Dockerfiles/open5gs-epc/open5gs-epc-aio
@@ -32,6 +32,7 @@ RUN apt-get update && \
         netbase \
         iptables \        
         net-tools \
+        dnsutils \         
         pkg-config && \
    apt-get clean && \
    git clone -b v2.2.6 --recursive https://github.com/open5gs/open5gs && \

--- a/Arm-Architecture/templates/hss-deploy.yaml
+++ b/Arm-Architecture/templates/hss-deploy.yaml
@@ -26,7 +26,11 @@ spec:
         - name: hss
           image: "{{ .Values.open5gs.image.repository }}:{{ .Values.open5gs.image.tag }}"
           imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
-          command: ["open5gs-hssd", "-c", "/open5gs/config-map/hss.yaml"]
+          command: ["/bin/sh", "-c"]
+          args:
+          - until nslookup s6a.mme.open5gs.service; do echo waiting for mme DNS record to be ready; done;
+            sleep 10;
+            open5gs-hssd -c /open5gs/config-map/hss.yaml
           volumeMounts:
           - name: open5gs-hss-config
             mountPath: /open5gs/config-map/hss.yaml

--- a/Arm-Architecture/templates/mme-deploy.yaml
+++ b/Arm-Architecture/templates/mme-deploy.yaml
@@ -27,7 +27,13 @@ spec:
       - name: mme
         image: "{{ .Values.open5gs.image.repository }}:{{ .Values.open5gs.image.tag }}"
         imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
-        command: ["open5gs-mmed", "-c", "/open5gs/config-map/mme.yaml"]
+        command: ["/bin/sh", "-c"]
+        args:
+        - until nslookup s6a.hss.open5gs.service; do echo waiting for hss DNS record to be ready; done;
+          until nslookup s11.sgwc.open5gs.service; do echo waiting for sgwc DNS record to be ready; done;
+          until nslookup s5.smf.open5gs.service; do echo waiting for smf DNS record to be ready; done;
+          sleep 10;
+          open5gs-mmed -c /open5gs/config-map/mme.yaml
         volumeMounts:
         - name: open5gs-mme-config
           mountPath: /open5gs/config-map/mme.yaml

--- a/Arm-Architecture/templates/pcrf-deploy.yaml
+++ b/Arm-Architecture/templates/pcrf-deploy.yaml
@@ -27,7 +27,11 @@ spec:
         - name: pcrf
           image: "{{ .Values.open5gs.image.repository }}:{{ .Values.open5gs.image.tag }}"
           imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
-          command: ["open5gs-pcrfd", "-c", "/open5gs/config-map/pcrf.yaml"]
+          command: ["/bin/sh", "-c"]
+          args:
+          - until nslookup s5.smf.open5gs.service; do echo waiting for smf DNS record to be ready; done;
+            sleep 10;
+            open5gs-pcrfd -c /open5gs/config-map/pcrf.yaml
           volumeMounts:
           - name: open5gs-pcrf-config
             mountPath: /open5gs/config-map/pcrf.yaml

--- a/Arm-Architecture/templates/sgw-c-deploy.yaml
+++ b/Arm-Architecture/templates/sgw-c-deploy.yaml
@@ -29,7 +29,9 @@ spec:
         imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
-        - open5gs-sgwcd -c /open5gs/config-map/sgwc.yaml;
+        - until nslookup sx.sgwu.open5gs.service; do echo waiting for sgwu DNS record to be ready; done;
+          sleep 10;
+          open5gs-sgwcd -c /open5gs/config-map/sgwc.yaml;
         volumeMounts:
           - name: open5gs-sgwc-config
             mountPath: /open5gs/config-map/sgwc.yaml

--- a/Arm-Architecture/templates/smf-deploy.yaml
+++ b/Arm-Architecture/templates/smf-deploy.yaml
@@ -29,7 +29,10 @@ spec:
         imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
-        - open5gs-smfd -c /open5gs/config-map/smf.yaml;
+        - until nslookup gx.pcrf.open5gs.service; do echo waiting for pcrf DNS record to be ready; done;
+          until nslookup sx.upf.open5gs.service; do echo waiting for upf DNS record to be ready; done;
+          sleep 10;
+          open5gs-smfd -c /open5gs/config-map/smf.yaml;
         volumeMounts:
           - name: open5gs-smf-config
             mountPath: /open5gs/config-map/smf.yaml

--- a/x86-Architecture/Dockerfiles/open5gs-epc/open5gs-epc-aio
+++ b/x86-Architecture/Dockerfiles/open5gs-epc/open5gs-epc-aio
@@ -32,6 +32,7 @@ RUN apt-get update && \
         netbase \
         net-tools \
         iptables \
+        dnsutils \        
         pkg-config && \
    apt-get clean && \
    git clone -b v2.2.6 --recursive https://github.com/open5gs/open5gs && \

--- a/x86-Architecture/templates/hss-deploy.yaml
+++ b/x86-Architecture/templates/hss-deploy.yaml
@@ -26,7 +26,11 @@ spec:
         - name: hss
           image: "{{ .Values.open5gs.image.repository }}:{{ .Values.open5gs.image.tag }}"
           imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
-          command: ["open5gs-hssd", "-c", "/open5gs/config-map/hss.yaml"]
+          command: ["/bin/sh", "-c"]
+          args:
+          - until nslookup s6a.mme.open5gs.service; do echo waiting for mme DNS record to be ready; done;
+            sleep 10;
+            open5gs-hssd -c /open5gs/config-map/hss.yaml
           volumeMounts:
           - name: open5gs-hss-config
             mountPath: /open5gs/config-map/hss.yaml

--- a/x86-Architecture/templates/mme-deploy.yaml
+++ b/x86-Architecture/templates/mme-deploy.yaml
@@ -27,7 +27,13 @@ spec:
       - name: mme
         image: "{{ .Values.open5gs.image.repository }}:{{ .Values.open5gs.image.tag }}"
         imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
-        command: ["open5gs-mmed", "-c", "/open5gs/config-map/mme.yaml"]
+        command: ["/bin/sh", "-c"]
+        args:
+        - until nslookup s6a.hss.open5gs.service; do echo waiting for hss DNS record to be ready; done;
+          until nslookup s11.sgwc.open5gs.service; do echo waiting for sgwc DNS record to be ready; done;
+          until nslookup s5.smf.open5gs.service; do echo waiting for smf DNS record to be ready; done;
+          sleep 10;
+          open5gs-mmed -c /open5gs/config-map/mme.yaml
         volumeMounts:
         - name: open5gs-mme-config
           mountPath: /open5gs/config-map/mme.yaml

--- a/x86-Architecture/templates/pcrf-deploy.yaml
+++ b/x86-Architecture/templates/pcrf-deploy.yaml
@@ -27,7 +27,11 @@ spec:
         - name: pcrf
           image: "{{ .Values.open5gs.image.repository }}:{{ .Values.open5gs.image.tag }}"
           imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
-          command: ["open5gs-pcrfd", "-c", "/open5gs/config-map/pcrf.yaml"]
+          command: ["/bin/sh", "-c"]
+          args:
+          - until nslookup s5.smf.open5gs.service; do echo waiting for smf DNS record to be ready; done;
+            sleep 10;
+            open5gs-pcrfd -c /open5gs/config-map/pcrf.yaml
           volumeMounts:
           - name: open5gs-pcrf-config
             mountPath: /open5gs/config-map/pcrf.yaml

--- a/x86-Architecture/templates/sgw-c-deploy.yaml
+++ b/x86-Architecture/templates/sgw-c-deploy.yaml
@@ -29,7 +29,9 @@ spec:
         imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
-        - open5gs-sgwcd -c /open5gs/config-map/sgwc.yaml;
+        - until nslookup sx.sgwu.open5gs.service; do echo waiting for sgwu DNS record to be ready; done;
+          sleep 10;
+          open5gs-sgwcd -c /open5gs/config-map/sgwc.yaml;
         volumeMounts:
           - name: open5gs-sgwc-config
             mountPath: /open5gs/config-map/sgwc.yaml

--- a/x86-Architecture/templates/smf-deploy.yaml
+++ b/x86-Architecture/templates/smf-deploy.yaml
@@ -29,7 +29,10 @@ spec:
         imagePullPolicy: {{ .Values.open5gs.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args:
-        - open5gs-smfd -c /open5gs/config-map/smf.yaml;
+        - until nslookup gx.pcrf.open5gs.service; do echo waiting for pcrf DNS record to be ready; done;
+          until nslookup sx.upf.open5gs.service; do echo waiting for upf DNS record to be ready; done;
+          sleep 10;         
+          open5gs-smfd -c /open5gs/config-map/smf.yaml;
         volumeMounts:
           - name: open5gs-smf-config
             mountPath: /open5gs/config-map/smf.yaml


### PR DESCRIPTION
*Description of changes:*
Improve Pod Initialization, this is particularly related to HSS, MME, PCRF, SGWC and SMF.

There should be no restarts as shown below:

```
[ec2-user@ip-10-0-0-53 ~]$ kubectl -n open5gs get po
NAME                                       READY   STATUS    RESTARTS   AGE
open5gs-hss-deployment-5b4d97cfb7-n4sms    1/1     Running   0          52s
open5gs-mme-deployment-c5f9579d5-glkpx     1/1     Running   0          51s
open5gs-nrf-deployment-57d6678866-qgjk9    1/1     Running   0          51s
open5gs-pcrf-deployment-59c7ccf6c6-zzd8p   1/1     Running   0          52s
open5gs-sgwc-deployment-787b8974c4-g4qnr   1/1     Running   0          52s
open5gs-sgwu-deployment-7ccdc4bf9f-mhbds   1/1     Running   0          51s
open5gs-smf-deployment-6c97877dc-6wt8v     1/1     Running   0          52s
open5gs-upf-deployment-6fb795ccfd-rqmrf    1/1     Running   0          52s
open5gs-webui-67d48c8ddf-v4s9m             1/1     Running   0          51s
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
