### PR TITLE
fix(docs): remove invalid flag on docker push

### DIFF
--- a/Build-Container-Images.md
+++ b/Build-Container-Images.md
@@ -20,7 +20,7 @@
  
 **Push images to your ECR:**
 
- docker push container_registry/open5gs-x86-aio:41fd851 -f open5gs-epc-aio
+ docker push container_registry/open5gs-x86-aio:41fd851
  
  docker push container_registry/open5gs-x86-web:41fd851
  


### PR DESCRIPTION
*Issue #, if available:*
Closes #8

*Description of changes:*
`docker push` does not need the `-f` flag. Updated docs accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
