### PR TITLE
api version "v1beta1" is no longer available since 1.22. Use "v1"

### DIFF
--- a/x86-Architecture/controllers/rbac/svc-watcher-route53-rbac.yaml
+++ b/x86-Architecture/controllers/rbac/svc-watcher-route53-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: multus-service-route53-monitor-pods
@@ -16,7 +16,7 @@ rules:
   verbs: ["get", "watch", "list"]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: multus-service-route53-monitor-pods


### PR DESCRIPTION
Reference: https://kubernetes.io/docs/reference/using-api/deprecation-guide/

*Issue #, if available:*
unable to recognize "controllers/rbac/aws-secondary-int-controller-rbac.yaml": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1"
unable to recognize "controllers/rbac/aws-secondary-int-controller-rbac.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
unable to recognize "controllers/rbac/svc-watcher-route53-rbac.yaml": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1"
unable to recognize "controllers/rbac/svc-watcher-route53-rbac.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"

*Description of changes:*
apiVersion 'v1beta1' is not available since 1.22. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
