### PR TITLE
For rbac, use "v1" as apiversion

### DIFF
--- a/x86-Architecture/controllers/rbac/aws-secondary-int-controller-rbac.yaml
+++ b/x86-Architecture/controllers/rbac/aws-secondary-int-controller-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: multus-sec-ip-operator
@@ -19,7 +19,7 @@ rules:
   verbs: ["create"]  
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: multus-sec-ip-operator


### PR DESCRIPTION
For rbac, use "v1" as apiversion

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
